### PR TITLE
RS-6579

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -227,8 +227,38 @@ log(spaces)
 
 <hr>
 
+## Get Plate
 
-### Get Plates
+### Description
+Fetches a single plate for the authenticated user.  
+You must provide **either** a `plate_id` or a `plate_name`—but not both.  
+If a matching plate exists, it is returned.
+
+##### <u>Params</u>
+* plate_id (`str`, optional): Unique ID of the plate to be fetched.  
+* plate_name (`str`, optional): Name of the plate to be fetched.  
+
+
+### Returns
+`plate` (`dict`): A plate object for the authenticated user.
+
+### Examples
+
+#### Fetch by `plate_id`
+```python
+# | eval: false
+plate_id = "00d1ac50-1149-11ee-85b5-bd8ec5ef4e32"
+plate = sdk.get_plate(plate_id=plate_id)
+log(plate)
+
+#### Fetch by `plate_name`
+```python
+# | eval: false
+plate_name = "finalPlateNameTest"
+plate = sdk.get_plate(plate_name=plate_name)
+log(plate)
+
+### Find Plates
 Fetches a list of plates for the authenticated user. If no `plate_id` is provided, returns all plates for the authenticated user. If `plate_id` is provided, returns the plate with the given `plate_id`, provided it exists. 
 
 ###### <u>Params</u>
@@ -242,7 +272,7 @@ Fetches a list of plates for the authenticated user. If no `plate_id` is provide
 ###### <u>Example</u>
 ```{python}
 #| eval: false
-plates = sdk.get_plates()
+plates = sdk.find_plates()
 log(plates)
 ```
 ```
@@ -253,7 +283,7 @@ You can also pass in a specific `plate_id` to specifically fetch a plate.
 ```{python}
 #| eval: false
 plate_id = "00d1ac50-1149-11ee-85b5-bd8ec5ef4e32"
-sample_plate = sdk.get_plates(plate_id)
+sample_plate = sdk.find_plates(plate_id)
 log(sample_plate)
 ```
 ```
@@ -263,7 +293,7 @@ log(sample_plate)
 With the `as_df` flag set to `True`:
 ```{python}
 #| eval: false
-sample_plate = sdk.get_plates(plate_id, as_df=True)
+sample_plate = sdk.find_plates(plate_id, as_df=True)
 log(sample_plate)
 ```
 ```
@@ -273,7 +303,7 @@ log(sample_plate)
 
 <hr>
 
-### Get MS Runs
+### Find MS Runs
 Fetches information pertaining to MS runs for passed in `sample_ids` (provided they are valid and contain relevant files) for an authenticated user. 
 
 The function returns a dict containing `DataFrame` objects if the `as_df` flag is passed in as True, otherwise a nested dict object is returned instead.
@@ -291,7 +321,7 @@ The function returns a dict containing `DataFrame` objects if the `as_df` flag i
 ```{python}
 #| eval: false
 sample_ids = ["812139c0-15e0-11ee-bdf1-bbaa73585acf", "803e05b0-15e0-11ee-bdf1-bbaa73585acf"]
-example = sdk.get_msruns(sample_ids)
+example = sdk.find_msruns(sample_ids)
 log(example)
 ```
 ```
@@ -301,7 +331,7 @@ log(example)
 There is also an option to return everything as a DataFrame instead:
 ```{python}
 #| eval: false
-example = sdk.get_msruns(sample_ids, as_df=True)
+example = sdk.find_msruns(sample_ids, as_df=True)
 log(example)
 ```
 ```
@@ -312,9 +342,33 @@ log(example)
 
 <hr>
 
+## Get Project
 
-### Get Projects
-Fetches a list of projects for the authenticated user. If no `project_id` is provided, returns all projects for the authenticated user. If `project_id` is provided, returns the project with the given `project_id`, provided it exists.
+### Description
+Fetches a single project for the authenticated user.  
+You must provide **either** a `project_id` or a `project_name`—but not both.  
+If a matching project exists, it is returned.
+
+##### <u>Params</u>
+* project_id (`str`, optional): Unique ID of the project to be fetched.  
+* project_name (`str`, optional): Name of the project to be fetched.  
+
+> **Note:** Exactly one of `project_id` or `project_name` must be provided.
+
+### <u>Returns</u>
+project: (`dict`) A project object for the authenticated user.
+
+### Examples
+
+#### Fetch by `project_id`
+```python
+# | eval: false
+project_id = "222e0890-0f95-11ee-9c0f-3bf27c252a07"
+project = sdk.get_project(project_id=project_id)
+log(project)
+
+### Find Projects
+Fetches a list of projects. If no `project_id` is provided, returns all projects. If `project_id` is provided, returns the project with the given `project_id`, provided it exists.
 
 The function returns a dict containing `DataFrame` objects if the `as_df` flag is passed in as True, otherwise a nested dict object is returned instead.
 
@@ -324,12 +378,12 @@ The function returns a dict containing `DataFrame` objects if the `as_df` flag i
 <br>
 
 ###### <u>Returns</u>
-`projects`: (`list[dict]` or `DataFrame`) `list[dict]` or `DataFrame` of project objects for the authenticated user.
+`projects`: (`list[dict]` or `DataFrame`) `list[dict]` or `DataFrame` of project objects.
 
 ###### <u>Example</u>
 ```{python}
 #| eval: false
-projects = sdk.get_projects()
+projects = sdk.find_projects()
 log(projects)
 ```
 ```
@@ -340,7 +394,7 @@ You can also pass in a specific `project_id` to specifically fetch a project.
 ```{python}
 #| eval: false
 project_id = "222e0890-0f95-11ee-9c0f-3bf27c252a07"
-sample_project = sdk.get_projects(project_id)
+sample_project = sdk.find_projects(project_id)
 log(sample_project)
 ```
 ```
@@ -421,8 +475,39 @@ log(samples)
 {'id': 'b6325471-d91f-11ef-85ce-51d48ea13827', 'user_group': None, 'plate_id': 'b50768f0-d91f-11ef-8371-dd35d1cfc768', 'sample_name': 'cleanup control', 'sample_id': 'CCLN', 'sample_type': 'Peptide', 'species': 'Human', 'description': 'NONE Lyo PC10 Peptides Controls Rep1', 'notes': None, 'created_by': '7485f2ae-9a12-4cc3-8605-98d10e624937', 'created_timestamp': '2025-01-23T00:19:29.584Z', 'last_modified_by': '7485f2ae-9a12-4cc3-8605-98d10e624937', 'last_modified_timestamp': '2025-01-23T00:19:29.852Z', 'sample_receipt_date': None, 'sample_collection_date': None, 'condition': 'B', 'plate_name': 'NoEdit_Biscayne_Plate_MS1048', 'custom_test': None, 'biological_replicate': None, 'technical_replicate': None, 'custom_new_field': None, 'custom_long_field_1234567890_123456890_1234567890_1234567890_63': None, 'custom_filed': None, 'custom_main_field': None, 'custom_letters_digits_anerscore': None, 'custom_test123': None, 'custom_sample_attribute_for_grouping': None, 'custom_custom_nita_01': None, 'custom_nitafield2': None, 'custom_by_demo_user': None, 'custom_seer_main_staging': None, 'custom_fix_713': None, 'custom_newcustomfield12345': None, 'custom_mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm': None, 'custom_reskin': None, 'custom_newaddedcolumn': None, 'custom_myfirsttestcustomcolumn0817': None, 'custom_sdk_test': None, 'custom_rsun_test_admin_custom_field': None, 'custom_age': None, 'custom_gender': None, 'custom_country': None, 'custom_res2': None, 'custom_region': None, 'custom_nation': None, 'custom_homer_field': None, 'custom_condition_1': None, 'well_location': 'D11', 'control': 'cleanup control'}]
 ```
 
-
 ### Get Analysis
+
+Fetches a single analysis object. You must provide either an analysis_id or an analysis_name (but not both).
+
+###### <u>Params</u>
+
+* analysis_id: (str, optional) Unique ID of the analysis to fetch.
+* analysis_name: (str, optional) Exact name of the analysis to fetch.
+
+Note: Exactly one of analysis_id or analysis_name must be provided.
+
+###### <u>Returns</u>
+
+analysis: (dict) A single analysis object.
+
+###### <u>Examples</u>
+
+```{python}
+# | eval: false
+analysis = sdk.get_analysis(analysis_id="00425a60-a850-11ea-b3d7-0171d11d0807")
+log(analysis)
+
+```{python}
+# | eval: false
+analysis = sdk.get_analysis(analysis_name="MYProject - 4 SAMPLE - NEW")
+log(analysis)
+```
+```
+{'id': '00425a60-a850-11ea-b3d7-0171d11d0807', 'analysis_name': 'MYPROJECT - 4 SAMPLE - NEW', 'description': 'DO NOT DELETE - FOR VISUALS', 'notes': '', 'analysis_protocol_id': 'b07d70f0-5471-11ea-90e8-6743ed53f19f', 'analyzed_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'start_time': '2020-06-06T23:46:54.360Z', 'end_time': '2020-06-07T03:23:30.614Z', 'last_modified_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'last_modified_timestamp': '2020-06-06T23:46:54.360Z', 'status': 'SUCCEEDED', 'result_folder': '2d89db50-805b-11ea-a3cb-5341c25962a0/00425a60-a850-11ea-b3d7-0171d11d0807/', 'job_id': '1c7dcdb9-21fe-47a3-9f9c-5326cc9662b2', 'user_group': None, 'project_id': '2d89db50-805b-11ea-a3cb-5341c25962a0', 'number_msdatafile': '20', 'protein_group_count': 3641, 'single_protein_group_count': 3184, 'possible_protein_set_size': 3878, 'peptides_count': 32274, 'contains_control': False, 'job_log_stream_name': None, 'contains_sample': True, 'is_folder': False, 'folder_id': None, 'number_sample': None, 'total_file_size_mb': None, 'msdatafile_extensions': None}
+```
+
+
+### Find Analyses
 Returns a list of analyses objects for the authenticated user. If no `analysis_id` is provided, returns all analyses for the authenticated user.
 
 ###### <u>Params</u>
@@ -435,7 +520,7 @@ Returns a list of analyses objects for the authenticated user. If no `analysis_i
 ###### <u>Example</u>
 ```{python}
 #| eval: false
-analyses = sdk.get_analyses()
+analyses = sdk.find_analyses()
 log(analyses)
 ```
 ```
@@ -446,11 +531,11 @@ You can also pass in a specific `analysis_id` to specifically fetch an analysis.
 ```{python}
 #| eval: false
 analysis_id = "00425a60-a850-11ea-b3d7-0171d11d0807"
-sample_analysis = sdk.get_analyses(analysis_id)
+sample_analysis = sdk.find_analyses(analysis_id)
 log(sample_analysis)
 ```
 ```
-[{'id': '00425a60-a850-11ea-b3d7-0171d11d0807', 'analysis_name': 'EXP19044 - 4 SAMPLE - NEW', 'description': 'DO NOT DELETE - FOR VISUALS', 'notes': '', 'analysis_protocol_id': 'b07d70f0-5471-11ea-90e8-6743ed53f19f', 'analyzed_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'start_time': '2020-06-06T23:46:54.360Z', 'end_time': '2020-06-07T03:23:30.614Z', 'last_modified_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'last_modified_timestamp': '2020-06-06T23:46:54.360Z', 'status': 'SUCCEEDED', 'result_folder': '2d89db50-805b-11ea-a3cb-5341c25962a0/00425a60-a850-11ea-b3d7-0171d11d0807/', 'job_id': '1c7dcdb9-21fe-47a3-9f9c-5326cc9662b2', 'user_group': None, 'project_id': '2d89db50-805b-11ea-a3cb-5341c25962a0', 'number_msdatafile': '20', 'protein_group_count': 3641, 'single_protein_group_count': 3184, 'possible_protein_set_size': 3878, 'peptides_count': 32274, 'contains_control': False, 'job_log_stream_name': None, 'contains_sample': True, 'is_folder': False, 'folder_id': None, 'number_sample': None, 'total_file_size_mb': None, 'msdatafile_extensions': None}]
+[{'id': '00425a60-a850-11ea-b3d7-0171d11d0807', 'analysis_name': 'MYPROJECT - 4 SAMPLE - NEW', 'description': 'DO NOT DELETE - FOR VISUALS', 'notes': '', 'analysis_protocol_id': 'b07d70f0-5471-11ea-90e8-6743ed53f19f', 'analyzed_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'start_time': '2020-06-06T23:46:54.360Z', 'end_time': '2020-06-07T03:23:30.614Z', 'last_modified_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'last_modified_timestamp': '2020-06-06T23:46:54.360Z', 'status': 'SUCCEEDED', 'result_folder': '2d89db50-805b-11ea-a3cb-5341c25962a0/00425a60-a850-11ea-b3d7-0171d11d0807/', 'job_id': '1c7dcdb9-21fe-47a3-9f9c-5326cc9662b2', 'user_group': None, 'project_id': '2d89db50-805b-11ea-a3cb-5341c25962a0', 'number_msdatafile': '20', 'protein_group_count': 3641, 'single_protein_group_count': 3184, 'possible_protein_set_size': 3878, 'peptides_count': 32274, 'contains_control': False, 'job_log_stream_name': None, 'contains_sample': True, 'is_folder': False, 'folder_id': None, 'number_sample': None, 'total_file_size_mb': None, 'msdatafile_extensions': None}]
 ```
 
 
@@ -490,11 +575,11 @@ log_df(analysis_data)
 ```
 ```
 File Name                         Sample Name     Plate ID Well Nanoparticle Protein Group  Intensity (Log10)  Normalized Intensity (Log10)                   Protein Names                    Gene Names Biological Process Molecular Function Cellular Component
-0          EXP19044_X4534_A_Orbitrap-1_2ug_60min.raw  Test-Sample-112A  EXP19044  B1     SP-0333      P56181-2          8.698                    0.030             Isoform of P56181, Isoform 2 of NADH dehydroge...   NDUFV3           NaN                NaN                NaN
-1          EXP19044_X4533_A_Orbitrap-1_2ug_60min.raw  Test-Sample-112A  EXP19044  B2     SP-0334      P56181-2          8.294                   -0.525             Isoform of P56181, Isoform 2 of NADH dehydroge...   NDUFV3           NaN                NaN                NaN
-2  EXP19044_X4541_A_Orbitrap-1_2ug_60min_20190829...  Test-Sample-110A  EXP19044  A4     SP-0336      P56181-2          8.780                   -0.156             Isoform of P56181, Isoform 2 of NADH dehydroge...   NDUFV3           NaN                NaN                NaN
-3  EXP19044_X4540_A_Orbitrap-1_2ug_60min_20190829...  Test-Sample-110A  EXP19044  A5     SP-0337      P56181-2          8.867                    0.137             Isoform of P56181, Isoform 2 of NADH dehydroge...   NDUFV3           NaN                NaN                NaN
-4  EXP19044_X4544_A_Orbitrap-1_2ug_60min_20190829...  Test-Sample-110A  EXP19044  A3     SP-0335      P56181-2          9.837                    0.992             Isoform of P56181, Isoform 2 of NADH dehydroge...   NDUFV3           NaN                NaN                NaN       
+0          MYPROJECT_X4534_A_Orbitrap-1_2ug_60min.raw  Test-Sample-112A  MYPROJECT  B1     SP-0333      P56181-2          8.698                    0.030             Isoform of P56181, Isoform 2 of NADH dehydroge...   NDUFV3           NaN                NaN                NaN
+1          MYPROJECT_X4533_A_Orbitrap-1_2ug_60min.raw  Test-Sample-112A  MYPROJECT  B2     SP-0334      P56181-2          8.294                   -0.525             Isoform of P56181, Isoform 2 of NADH dehydroge...   NDUFV3           NaN                NaN                NaN
+2  MYPROJECT_X4541_A_Orbitrap-1_2ug_60min_20190829...  Test-Sample-110A  MYPROJECT  A4     SP-0336      P56181-2          8.780                   -0.156             Isoform of P56181, Isoform 2 of NADH dehydroge...   NDUFV3           NaN                NaN                NaN
+3  MYPROJECT_X4540_A_Orbitrap-1_2ug_60min_20190829...  Test-Sample-110A  MYPROJECT  A5     SP-0337      P56181-2          8.867                    0.137             Isoform of P56181, Isoform 2 of NADH dehydroge...   NDUFV3           NaN                NaN                NaN
+4  MYPROJECT_X4544_A_Orbitrap-1_2ug_60min_20190829...  Test-Sample-110A  MYPROJECT  A3     SP-0335      P56181-2          9.837                    0.992             Isoform of P56181, Isoform 2 of NADH dehydroge...   NDUFV3           NaN                NaN                NaN       
 ```
 
 #### Download Search Output Files

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -246,18 +246,27 @@ If a matching plate exists, it is returned.
 
 #### Fetch by `plate_id`
 ```python
-# | eval: false
+#| eval: false
 plate_id = "00d1ac50-1149-11ee-85b5-bd8ec5ef4e32"
 plate = sdk.get_plate(plate_id=plate_id)
 log(plate)
+```
+```
+{'id': '00d1ac50-1149-11ee-85b5-bd8ec5ef4e32', 'plate_name': 'finalPlateNameTest', 'plate_id': 'finalPlateIdTest', 'description': None, 'notes': None, 'created_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'created_timestamp': '2023-06-22T22:06:13.963Z', 'last_modified_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'last_modified_timestamp': '2023-06-22T22:06:18.470Z', 'user_group': None}
+```
 
 #### Fetch by `plate_name`
 ```python
-# | eval: false
+#| eval: false
 plate_name = "finalPlateNameTest"
 plate = sdk.get_plate(plate_name=plate_name)
 log(plate)
+```
+```
+{'id': '00d1ac50-1149-11ee-85b5-bd8ec5ef4e32', 'plate_name': 'finalPlateNameTest', 'plate_id': 'finalPlateIdTest', 'description': None, 'notes': None, 'created_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'created_timestamp': '2023-06-22T22:06:13.963Z', 'last_modified_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'last_modified_timestamp': '2023-06-22T22:06:18.470Z', 'user_group': None}
+```
 
+<hr>
 ### Find Plates
 Fetches a list of plates for the authenticated user. If no `plate_id` is provided, returns all plates for the authenticated user. If `plate_id` is provided, returns the plate with the given `plate_id`, provided it exists. 
 
@@ -362,10 +371,26 @@ project: (`dict`) A project object for the authenticated user.
 
 #### Fetch by `project_id`
 ```python
-# | eval: false
+#| eval: false
 project_id = "222e0890-0f95-11ee-9c0f-3bf27c252a07"
 project = sdk.get_project(project_id=project_id)
 log(project)
+```
+```
+{'id': '222e0890-0f95-11ee-9c0f-3bf27c252a07', 'project_name': 'sdk test projjjjjj', 'description': None, 'notes': None, 'created_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'created_timestamp': '2023-06-20T18:06:09.397Z', 'last_modified_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'last_modified_timestamp': '2023-06-20T18:06:09.397Z', 'user_group': None}
+```
+#### Fetch by `project_name`
+```python
+#| eval: false
+project_name = "sdk test projjjjjj"
+project = sdk.get_project(project_name=project_name)
+log(project)
+```
+```
+{'id': '222e0890-0f95-11ee-9c0f-3bf27c252a07', 'project_name': 'sdk test projjjjjj', 'description': None, 'notes': None, 'created_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'created_timestamp': '2023-06-20T18:06:09.397Z', 'last_modified_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'last_modified_timestamp': '2023-06-20T18:06:09.397Z', 'user_group': None}
+```
+
+<hr>
 
 ### Find Projects
 Fetches a list of projects. If no `project_id` is provided, returns all projects. If `project_id` is provided, returns the project with the given `project_id`, provided it exists.
@@ -403,9 +428,50 @@ log(sample_project)
 
 <hr>
 
+## Get Analysis Protocol
+
+Fetches a single analysis protocol object. You must provide either `analysis_protocol_id` or `analysis_protocol_name` (but not both).
+
+### <u>Params</u>
+
+* `analysis_protocol_id`: (`str`, optional) Unique ID of the analysis protocol to fetch.
+* `analysis_protocol_name`: (`str`, optional) Exact name of the analysis protocol to fetch.
+
+> **Note:** Exactly one of `analysis_protocol_id` or `analysis_protocol_name` must be provided.
+
+### <u>Returns</u>
+
+`protocol`: (`dict`) A single analysis protocol object.
+
+<u>Examples</u>
+
+Fetch by ID:
+```{python}
+#| eval: false
+protocol = sdk.get_analysis_protocol(
+    analysis_protocol_id="dc61a360-6b77-11ed-8ac3-37d35135f08e"
+)
+log(protocol)
+```
+```
+{'id': 'dc61a360-6b77-11ed-8ac3-37d35135f08e', 'analysis_protocol_name': 'testMSFraggerUpload26', 'analysis_type': 'DDA', 'version_number': '1', 'description': '', 'notes': '', 'created_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'created_timestamp': '2022-11-23T21:43:26.142Z', 'parameter_file_path': 'msfragger-parameter/testMSFraggerUpload26.json', 'user_group': None, 'species': 'Human', 'alg_version': '3.4', 'analysis_engine': 'msfragger', 'scope': 'user'}
+```
+Fetch by name:
+```{python}
+#| eval: false
+protocol = sdk.get_analysis_protocol(
+    analysis_protocol_name="testMSFraggerUpload26"
+)
+log(protocol)
+```
+```
+{'id': 'dc61a360-6b77-11ed-8ac3-37d35135f08e', 'analysis_protocol_name': 'testMSFraggerUpload26', 'analysis_type': 'DDA', 'version_number': '1', 'description': '', 'notes': '', 'created_by': '04936dea-d255-4130-8e82-2f28938a8f9a', 'created_timestamp': '2022-11-23T21:43:26.142Z', 'parameter_file_path': 'msfragger-parameter/testMSFraggerUpload26.json', 'user_group': None, 'species': 'Human', 'alg_version': '3.4', 'analysis_engine': 'msfragger', 'scope': 'user'}
+```
+
+<hr>
 
 
-### Get Analysis Protocols
+### Find Analysis Protocols
 Fetches a list of analysis protocols for the authenticated user. If no analysis_id is provided, returns all analysis protocols for the authenticated user. If name (and no analysis_id) is provided, returns the analysis protocol with the given name, provided it exists. 
 
 ###### <u>Params</u>
@@ -419,7 +485,7 @@ Fetches a list of analysis protocols for the authenticated user. If no analysis_
 ###### <u>Example</u>
 ```{python}
 #| eval: false
-analysis_protocols = sdk.get_analysis_protocols()
+analysis_protocols = sdk.find_analysis_protocols()
 log(analysis_protocols)
 ```
 ```
@@ -430,7 +496,7 @@ You can also pass in a specific `name` to specifically fetch an analysis protoco
 ```{python}
 #| eval: false
 protocol_name = "testMSFraggerUpload26"
-sample_analysis_protocol = sdk.get_analysis_protocols(analysis_protocol_name=protocol_name)
+sample_analysis_protocol = sdk.find_analysis_protocols(analysis_protocol_name=protocol_name)
 log(sample_analysis_protocol)
 ```
 ```
@@ -441,7 +507,7 @@ The same can be done for `analysis_id`.
 ```{python}
 #| eval: false
 protocol_id = "dc61a360-6b77-11ed-8ac3-37d35135f08e"
-sample_analysis_protocol = sdk.get_analysis_protocols(analysis_protocol_id=protocol_id)
+sample_analysis_protocol = sdk.find_analysis_protocols(analysis_protocol_id=protocol_id)
 log(sample_analysis_protocol)
 ```
 ```
@@ -450,7 +516,7 @@ log(sample_analysis_protocol)
 
 <hr>
 
-### Get Samples 
+### Find Samples 
 Fetches a list of samples for the authenticated user. Samples can be fetched with respect to a `plate_id`, `project_id`, `analysis_id`, `analysis_name`. 
 
 ###### <u>Params</u>
@@ -466,7 +532,7 @@ Fetches a list of samples for the authenticated user. Samples can be fetched wit
 ###### <u>Example</u>
 ```{python}
 #| eval: false
-samples = sdk.get_samples(plate_id="303bfc20-87d7-11ee-b03f-27a54e8c1798")
+samples = sdk.find_samples(plate_id="303bfc20-87d7-11ee-b03f-27a54e8c1798")
 log(samples)
 ```
 
@@ -493,12 +559,12 @@ analysis: (dict) A single analysis object.
 ###### <u>Examples</u>
 
 ```{python}
-# | eval: false
+#| eval: false
 analysis = sdk.get_analysis(analysis_id="00425a60-a850-11ea-b3d7-0171d11d0807")
 log(analysis)
 
 ```{python}
-# | eval: false
+#| eval: false
 analysis = sdk.get_analysis(analysis_name="MYProject - 4 SAMPLE - NEW")
 log(analysis)
 ```

--- a/seer_pas_sdk/core/sdk.py
+++ b/seer_pas_sdk/core/sdk.py
@@ -263,7 +263,7 @@ class SeerSDK:
     @deprecation.deprecated(
         deprecated_in="1.1.0",
         removed_in="2.0.0",
-        text="This method is deprecated and will be removed in a future release. Use `find_plates` instead.",
+        details="This method is deprecated and will be removed in a future release. Use `find_plates` instead.",
     )
     def get_plates(
         self, plate_id: str = None, plate_name: str = None, as_df: bool = False
@@ -340,10 +340,8 @@ class SeerSDK:
                 del entry["tenant_id"]
 
         return res if not as_df else dict_to_df(res)
-    
-    def get_plate(
-        self, plate_id: str = None, plate_name: str = None
-    ):
+
+    def get_plate(self, plate_id: str = None, plate_name: str = None):
         """
         Fetches a plate.
 
@@ -351,7 +349,7 @@ class SeerSDK:
         ----------
         plate_id : str, optional
             ID of the plate to be fetched, defaulted to None.
-        
+
         plate_name : str, optional
             Name of the plate to be fetched, defaulted to None.
 
@@ -364,7 +362,7 @@ class SeerSDK:
             raise ValueError(
                 "You must provide either plate_id or plate_name, but not both."
             )
-        
+
         if plate_id:
             URL = f"{self._auth.url}api/v1/plates/{plate_id}"
             with self._get_auth_session("getplate") as s:
@@ -379,9 +377,7 @@ class SeerSDK:
         else:
             res = self.find_plates(plate_name=plate_name)
             if not res:
-                raise ValueError(
-                    f"No plate found with name '{plate_name}'."
-                )
+                raise ValueError(f"No plate found with name '{plate_name}'.")
             elif len(res) > 1:
                 raise ValueError(
                     f"Multiple plates found with name '{plate_name}'. Please specify a plate_id."
@@ -468,7 +464,7 @@ class SeerSDK:
     @deprecation.deprecated(
         deprecated_in="1.1.0",
         removed_in="2.0.0",
-        text="This method is deprecated and will be removed in a future release. Use `find_projects` instead.",
+        details="This method is deprecated and will be removed in a future release. Use `find_projects` instead.",
     )
     def get_projects(
         self,
@@ -561,12 +557,7 @@ class SeerSDK:
                 ]
         return res if not as_df else dict_to_df(res)
 
-
-    def get_project(
-            self,
-            project_id: str = None,
-            project_name: str = None
-    ):
+    def get_project(self, project_id: str = None, project_name: str = None):
         """
         Fetches a project.
 
@@ -574,7 +565,7 @@ class SeerSDK:
         ----------
         project_id: str, optional
             ID of the project to be fetched, defaulted to None.
-        
+
         project_name: str, optional
             Name of the project to be fetched, defaulted to None.
 
@@ -587,7 +578,7 @@ class SeerSDK:
             raise ValueError(
                 "You must provide either project_id or project_name, but not both."
             )
-        
+
         if project_id:
             URL = f"{self._auth.url}api/v1/projects/{project_id}"
             with self._get_auth_session("getproject") as s:
@@ -611,6 +602,7 @@ class SeerSDK:
                 )
             else:
                 return res[0]
+
     def find_projects(
         self,
         project_id: str = None,
@@ -701,7 +693,7 @@ class SeerSDK:
     @deprecation.deprecated(
         deprecated_in="1.1.0",
         removed_in="2.0.0",
-        text="This method is deprecated and will be removed in a future release. Use `find_samples` instead.",
+        details="This method is deprecated and will be removed in a future release. Use `find_samples` instead.",
     )
     def get_samples(
         self,
@@ -833,12 +825,6 @@ class SeerSDK:
         ]
 
         return res_df.to_dict(orient="records") if not as_df else res_df
-    
-    def get_sample(
-            self,
-            sample_id: str = None,
-            sample_name: str = None
-    )
 
     def find_samples(
         self,
@@ -955,7 +941,6 @@ class SeerSDK:
                     analysis_name=analysis_name, as_df=True, is_name=True
                 )
 
-
         # apply post processing
         res_df.drop(["tenant_id"], axis=1, inplace=True)
 
@@ -1059,7 +1044,7 @@ class SeerSDK:
     @deprecation.deprecated(
         deprecated_in="1.1.0",
         removed_in="2.0.0",
-        text="This method is deprecated and will be removed in a future release. Use `find_msruns` instead.",
+        details="This method is deprecated and will be removed in a future release. Use `find_msruns` instead.",
     )
     def get_msruns(self, sample_ids: list, as_df: bool = False):
         """
@@ -1152,13 +1137,13 @@ class SeerSDK:
         >>> seer_sdk = SeerSDK()
         >>> sample_ids = ["812139c0-15e0-11ee-bdf1-bbaa73585acf", "803e05b0-15e0-11ee-bdf1-bbaa73585acf"]
 
-        >>> seer_sdk.get_msruns(sample_ids)
+        >>> seer_sdk.find_msruns(sample_ids)
         >>> [
             {"id": "SAMPLE_ID_1_HERE" ... },
             {"id": "SAMPLE_ID_2_HERE" ... }
         ]
 
-        >>> seer_sdk.get_msruns(sample_ids, as_df=True)
+        >>> seer_sdk.find_msruns(sample_ids, as_df=True)
         >>>                                      id  ... gradient
             0  81c6a180-15e0-11ee-bdf1-bbaa73585acf  ...     None
             1  816a9ed0-15e0-11ee-bdf1-bbaa73585acf  ...     None
@@ -1198,7 +1183,7 @@ class SeerSDK:
     @deprecation.deprecated(
         deprecated_in="1.1.0",
         removed_in="2.0.0",
-        text="This method is deprecated and will be removed in a future release. Use `find_analysis_protocols` instead.",
+        details="This method is deprecated and will be removed in a future release. Use `find_analysis_protocols` instead.",
     )
     def get_analysis_protocols(
         self,
@@ -1296,7 +1281,7 @@ class SeerSDK:
                     ][location(res[entry]["parameter_file_path"]) :]
 
             return res if not as_df else dict_to_df(res)
-        
+
     def get_analysis_protocol(
         self,
         analysis_protocol_id: str = None,
@@ -1417,7 +1402,7 @@ class SeerSDK:
                     "Invalid request. Please check your parameters."
                 )
             if analysis_protocol_id:
-                res = [protocols.json()]
+                res = protocols.json()["data"]
             else:
                 res = protocols.json()["data"]
 
@@ -1447,7 +1432,7 @@ class SeerSDK:
     @deprecation.deprecated(
         deprecated_in="1.1.0",
         removed_in="2.0.0",
-        text="This method is deprecated and will be removed in a future release. Use `find_analyses` instead.",
+        details="This method is deprecated and will be removed in a future release. Use `find_analyses` instead.",
     )
     def get_analyses(
         self,
@@ -1615,24 +1600,23 @@ class SeerSDK:
                 ]
             return res if not as_df else dict_to_df(res)
 
-
     def get_analysis(
         self,
         analysis_id: str = None,
         analysis_name: str = None,
     ):
-        """ Fetches an analysis.
+        """Fetches an analysis.
 
         Args:
             analysis_id (str, optional): id of the analysis to be fetched. Defaults to None.
             analysis_name (str, optional): name of the analysis to be fetched. Defaults to None.
-        
+
         Returns:
             analysis : dict
                 Analysis object
         Examples
         -------
-        >>> from seer_pas_sdk import SeerSDK 
+        >>> from seer_pas_sdk import SeerSDK
         >>> seer_sdk = SeerSDK()
         >>> seer_sdk.get_analysis(analysis_id="YOUR_ANALYSIS_ID_HERE")
         >>> { "id": ..., "analysis_name": ... }
@@ -1652,7 +1636,8 @@ class SeerSDK:
                         "Invalid request. Please check your parameters."
                     )
                 res = analysis.json()
-                del res["tenant_id"]
+                if "tenant_id" in res:
+                    del res["tenant_id"]
                 return res
         else:
             res = self.find_analyses(analysis_name=analysis_name)
@@ -1666,11 +1651,6 @@ class SeerSDK:
                 )
             else:
                 return res[0]
-
-
-
-
-
 
     def find_analyses(
         self,

--- a/seer_pas_sdk/core/sdk.py
+++ b/seer_pas_sdk/core/sdk.py
@@ -260,6 +260,11 @@ class SeerSDK:
                 )
             return spaces.json()
 
+    @deprecation.deprecated(
+        deprecated_in="1.1.0",
+        removed_in="2.0.0",
+        text="This method is deprecated and will be removed in a future release. Use `find_plates` instead.",
+    )
     def get_plates(
         self, plate_id: str = None, plate_name: str = None, as_df: bool = False
     ):
@@ -336,6 +341,87 @@ class SeerSDK:
 
         return res if not as_df else dict_to_df(res)
 
+    def find_plates(
+        self, plate_id: str = None, plate_name: str = None, as_df: bool = False
+    ):
+        """
+        Fetches a list of plates for the authenticated user. If no `plate_id` is provided, returns all plates for the authenticated user. If `plate_id` is provided, returns the plate with the given `plate_id`, provided it exists.
+
+        Parameters
+        ----------
+        plate_id : str, optional
+            ID of the plate to be fetched, defaulted to None.
+        as_df: bool
+            whether the result should be converted to a DataFrame, defaulted to None.
+
+        Returns
+        -------
+        plates: list[dict] or DataFrame
+            List/DataFrame of plate objects for the authenticated user.
+
+        Examples
+        -------
+        >>> from seer_pas_sdk import SeerSDK
+        >>> seer_sdk = SeerSDK()
+        >>> seer_sdk.get_plates()
+        >>> [
+                { "id": ... },
+                { "id": ... },
+                ...
+            ]
+        >>> seer_sdk.get_plates(as_df=True)
+        >>>                                        id  ... user_group
+            0    a7c12190-15da-11ee-bdf1-bbaa73585acf  ...       None
+            1    8c3b1480-15da-11ee-bdf1-bbaa73585acf  ...       None
+            2    6f158840-15da-11ee-bdf1-bbaa73585acf  ...       None
+            3    1a8a2920-15da-11ee-bdf1-bbaa73585acf  ...       None
+            4    7ab47f40-15d9-11ee-bdf1-bbaa73585acf  ...       None
+            ..                                    ...  ...        ...
+            935  8fa91c00-6621-11ea-96e3-d5a4dab4ebf6  ...       None
+            936  53180b20-6621-11ea-96e3-d5a4dab4ebf6  ...       None
+            937  5c31fe90-6618-11ea-96e3-d5a4dab4ebf6  ...       None
+            938  5b05d440-6610-11ea-96e3-d5a4dab4ebf6  ...       None
+            939  9872e3f0-544e-11ea-ad9e-1991e0725494  ...       None
+
+        >>> seer_sdk.get_plate_metadata(id="YOUR_PLATE_ID_HERE")
+        >>> [{ "id": ... }]
+        """
+
+        URL = f"{self._auth.url}api/v1/plates"
+        res = []
+
+        if not plate_id and not plate_name:
+            params = {"all": "true"}
+        elif plate_name:
+            params = {"searchFields": "plate_name", "searchItem": plate_name}
+        else:
+            params = dict()
+
+        with self._get_auth_session("findplates") as s:
+
+            plates = s.get(
+                f"{URL}/{plate_id}" if plate_id else URL,
+                params=params,
+            )
+            if plates.status_code != 200:
+                raise ValueError(
+                    "Invalid request. Please check your parameters."
+                )
+            if not plate_id:
+                res = plates.json()["data"]
+            else:
+                res = [plates.json()]
+
+            for entry in res:
+                del entry["tenant_id"]
+
+        return res if not as_df else dict_to_df(res)
+
+    @deprecation.deprecated(
+        deprecated_in="1.1.0",
+        removed_in="2.0.0",
+        text="This method is deprecated and will be removed in a future release. Use `find_projects` instead.",
+    )
     def get_projects(
         self,
         project_id: str = None,
@@ -427,6 +513,98 @@ class SeerSDK:
                 ]
         return res if not as_df else dict_to_df(res)
 
+    def find_projects(
+        self,
+        project_id: str = None,
+        project_name: str = None,
+        as_df: bool = False,
+    ):
+        """
+        Fetches a list of projects for the authenticated user. If no `project_id` is provided, returns all projects for the authenticated user. If `project_id` is provided, returns the project with the given `project_id`, provided it exists.
+
+        Parameters
+        ----------
+        project_id: str, optional
+            Project ID of the project to be fetched, defaulted to None.
+        as_df: bool
+            whether the result should be converted to a DataFrame, defaulted to False.
+
+        Returns
+        -------
+        projects: list[dict] or DataFrame
+            DataFrame or list of project objects for the authenticated user.
+
+        Examples
+        -------
+        >>> from seer_pas_sdk import SeerSDK
+        >>> seer_sdk = SeerSDK()
+        >>> seer_sdk.get_projects()
+        >>> [
+                { "project_name": ... },
+                { "project_name": ... },
+                ...
+            ]
+
+        >>> seer_sdk.get_projects(as_df=True)
+        >>>                                        id  ... user_group
+            0    a7c12190-15da-11ee-bdf1-bbaa73585acf  ...       None
+            1    8c3b1480-15da-11ee-bdf1-bbaa73585acf  ...       None
+            2    6f158840-15da-11ee-bdf1-bbaa73585acf  ...       None
+            3    1a8a2920-15da-11ee-bdf1-bbaa73585acf  ...       None
+            4    7ab47f40-15d9-11ee-bdf1-bbaa73585acf  ...       None
+            ..                                    ...  ...        ...
+            935  8fa91c00-6621-11ea-96e3-d5a4dab4ebf6  ...       None
+            936  53180b20-6621-11ea-96e3-d5a4dab4ebf6  ...       None
+            937  5c31fe90-6618-11ea-96e3-d5a4dab4ebf6  ...       None
+            938  5b05d440-6610-11ea-96e3-d5a4dab4ebf6  ...       None
+            939  9872e3f0-544e-11ea-ad9e-1991e0725494  ...       None
+
+        >>> seer_sdk.get_projects(id="YOUR_PROJECT_ID_HERE")
+        >>> [{ "project_name": ... }]
+        """
+
+        URL = f"{self._auth.url}api/v1/projects"
+        res = []
+        if not project_id and not project_name:
+            params = {"all": "true"}
+        elif project_name:
+            params = {
+                "searchFields": "project_name",
+                "searchItem": project_name,
+            }
+        else:
+            params = {"searchFields": "id", "searchItem": project_id}
+
+        with self._get_auth_session("getprojects") as s:
+
+            projects = s.get(URL, params=params)
+            if projects.status_code != 200:
+                raise ValueError(
+                    "Invalid request. Please check your parameters."
+                )
+            res = projects.json()["data"]
+
+            if project_id and not res:
+                raise ValueError("Project ID is invalid.")
+
+        for entry in res:
+            if "tenant_id" in entry:
+                del entry["tenant_id"]
+
+            if "raw_file_path" in entry:
+                # Simple lambda function to find the third occurrence of '/' in the raw file path
+                location = lambda s: len(s) - len(s.split("/", 3)[-1])
+                # Slicing the string from the location
+                entry["raw_file_path"] = entry["raw_file_path"][
+                    location(entry["raw_file_path"]) :
+                ]
+        return res if not as_df else dict_to_df(res)
+
+    @deprecation.deprecated(
+        deprecated_in="1.1.0",
+        removed_in="2.0.0",
+        text="This method is deprecated and will be removed in a future release. Use `find_samples` instead.",
+    )
     def get_samples(
         self,
         plate_id: str = None,
@@ -558,6 +736,137 @@ class SeerSDK:
 
         return res_df.to_dict(orient="records") if not as_df else res_df
 
+    def find_samples(
+        self,
+        plate_id: str = None,
+        project_id: str = None,
+        analysis_id: str = None,
+        analysis_name: str = None,
+        as_df: bool = False,
+    ):
+        """
+        Fetches a list of samples for the authenticated user with relation to a specified plate, project, or analysis. If no parameters are provided, returns all samples for the authenticated user. If `plate_id` or `project_id` is provided, returns samples associated with that plate or project. If `analysis_id` or `analysis_name` is provided, returns samples associated with that analysis.
+
+        Parameters
+        ----------
+        plate_id : str, optional
+            ID of the plate for which samples are to be fetched, defaulted to None.
+        project_id : str, optional
+            ID of the project for which samples are to be fetched, defaulted to None.
+        analysis_id : str, optional
+            ID of the analysis for which samples are to be fetched, defaulted to None.
+        analysis_name : str, optional
+            Name of the analysis for which samples are to be fetched, defaulted to None.
+        as_df: bool
+            whether the result should be converted to a DataFrame, defaulted to False.
+
+        Returns
+        -------
+        samples: list[dict] or DataFrame
+            List/DataFrame of samples for the authenticated user.
+
+        Examples
+        -------
+        >>> from seer_pas_sdk import SeerSDK
+        >>> seer_sdk = SeerSDK()
+
+        >>> seer_sdk.get_samples(plate_id="7ec8cad0-15e0-11ee-bdf1-bbaa73585acf")
+        >>> [
+                { "id": ... },
+                { "id": ... },
+                ...
+            ]
+
+        >>> seer_sdk.get_samples(as_df=True)
+        >>>                                     id  ...      control
+        0     812139c0-15e0-11ee-bdf1-bbaa73585acf  ...
+        1     803e05b0-15e0-11ee-bdf1-bbaa73585acf  ...  MPE Control
+        2     a9b26a40-15da-11ee-bdf1-bbaa73585acf  ...
+        3     a8fc87c0-15da-11ee-bdf1-bbaa73585acf  ...  MPE Control
+        4     8e322990-15da-11ee-bdf1-bbaa73585acf  ...
+        ...                                    ...  ...          ...
+        3624  907e1f40-6621-11ea-96e3-d5a4dab4ebf6  ...         C132
+        3625  53e59450-6621-11ea-96e3-d5a4dab4ebf6  ...         C132
+        3626  5d11b030-6618-11ea-96e3-d5a4dab4ebf6  ...         C132
+        3627  5bdf9270-6610-11ea-96e3-d5a4dab4ebf6  ...         C132
+        3628  dd607ef0-654c-11ea-8eb2-25a1cfd1163c  ...         C132
+        """
+
+        # Raise an error if none or more than one of the primary key parameters are passed in.
+        if (
+            sum(
+                [
+                    True if x else False
+                    for x in [plate_id, project_id, analysis_id, analysis_name]
+                ]
+            )
+            != 1
+        ):
+            raise ValueError(
+                "You must pass in exactly one of plate_id, project_id, analysis_id, analysis_name."
+            )
+
+        res = []
+        URL = f"{self._auth.url}api/v1/samples"
+        sample_params = {"all": "true"}
+
+        if project_id or plate_id:
+            with self._get_auth_session("findsamples") as s:
+                if plate_id:
+                    try:
+                        self.find_plates(plate_id)
+                    except:
+                        raise ValueError("Plate ID is invalid.")
+                    sample_params["plateId"] = plate_id
+
+                else:
+                    try:
+                        self.find_projects(project_id)
+                    except:
+                        raise ValueError("Project ID is invalid.")
+
+                    sample_params["projectId"] = project_id
+
+            samples = s.get(URL, params=sample_params)
+            if samples.status_code != 200:
+                raise ValueError(
+                    f"Failed to fetch sample data for plate ID: {plate_id}."
+                )
+            res = samples.json()["data"]
+            if not res:
+                return [] if not as_df else dict_to_df(res)
+            res_df = dict_to_df(res)
+
+            # API returns empty strings if not a control, replace with None for filtering purposes
+            res_df["control"] = res_df["control"].apply(
+                lambda x: x if x else None
+            )
+        else:
+            if analysis_id:
+                res_df = self._get_analysis_samples(
+                    analysis_id=analysis_id, as_df=True
+                )
+            else:
+                res_df = self._get_analysis_samples(
+                    analysis_name=analysis_name, as_df=True, is_name=True
+                )
+
+        # apply post processing
+        res_df.drop(["tenant_id"], axis=1, inplace=True)
+
+        custom_columns = [
+            x["field_name"] for x in self._get_sample_custom_fields()
+        ]
+        res_df = res_df[
+            [
+                x
+                for x in res_df.columns
+                if not x.startswith("custom_") or x in custom_columns
+            ]
+        ]
+
+        return res_df.to_dict(orient="records") if not as_df else res_df
+
     def _filter_samples_metadata(
         self,
         project_id: str,
@@ -642,6 +951,11 @@ class SeerSDK:
                 del entry["tenant_id"]
             return res
 
+    @deprecation.deprecated(
+        deprecated_in="1.1.0",
+        removed_in="2.0.0",
+        text="This method is deprecated and will be removed in a future release. Use `find_msruns` instead.",
+    )
     def get_msruns(self, sample_ids: list, as_df: bool = False):
         """
         Fetches MS data files for passed in `sample_ids` (provided they are valid and contain relevant files) for an authenticated user.
@@ -709,6 +1023,78 @@ class SeerSDK:
                 ]
         return res if not as_df else dict_to_df(res)
 
+    def find_msruns(self, sample_ids: list, as_df: bool = False):
+        """
+        Fetches MS data files for passed in `sample_ids` (provided they are valid and contain relevant files) for an authenticated user.
+
+        The function returns a dict containing DataFrame objects if the `df` flag is passed in as True, otherwise a nested dict object is returned instead.
+
+        Parameters
+        ----------
+        sample_ids : list
+            List of unique sample IDs.
+        as_df: bool
+            whether the result should be converted to a DataFrame, defaulted to False.
+
+        Returns
+        -------
+        res: list[dict] or DataFrame
+            List/DataFrame of plate objects for the authenticated user.
+
+        Examples
+        -------
+        >>> from seer_pas_sdk import SeerSDK
+        >>> seer_sdk = SeerSDK()
+        >>> sample_ids = ["812139c0-15e0-11ee-bdf1-bbaa73585acf", "803e05b0-15e0-11ee-bdf1-bbaa73585acf"]
+
+        >>> seer_sdk.get_msruns(sample_ids)
+        >>> [
+            {"id": "SAMPLE_ID_1_HERE" ... },
+            {"id": "SAMPLE_ID_2_HERE" ... }
+        ]
+
+        >>> seer_sdk.get_msruns(sample_ids, as_df=True)
+        >>>                                      id  ... gradient
+            0  81c6a180-15e0-11ee-bdf1-bbaa73585acf  ...     None
+            1  816a9ed0-15e0-11ee-bdf1-bbaa73585acf  ...     None
+
+            [2 rows x 26 columns]
+        """
+
+        URL = f"{self._auth.url}api/v1/msdatas/items"
+
+        res = []
+        for sample_id in sample_ids:
+
+            with self._get_auth_session("getmsdatas") as s:
+
+                msdatas = s.post(URL, json={"sampleId": sample_id})
+
+                if msdatas.status_code != 200 or not msdatas.json()["data"]:
+                    raise ValueError(
+                        f"Failed to fetch MS data for sample ID={sample_id}."
+                    )
+
+                res += [x for x in msdatas.json()["data"]]
+
+        for entry in res:
+            if "tenant_id" in entry:
+                del entry["tenant_id"]
+
+            if "raw_file_path" in entry:
+                # Simple lambda function to find the third occurrence of '/' in the raw file path
+                location = lambda s: len(s) - len(s.split("/", 3)[-1])
+                # Slicing the string from the location
+                entry["raw_file_path"] = entry["raw_file_path"][
+                    location(entry["raw_file_path"]) :
+                ]
+        return res if not as_df else dict_to_df(res)
+
+    @deprecation.deprecated(
+        deprecated_in="1.1.0",
+        removed_in="2.0.0",
+        text="This method is deprecated and will be removed in a future release. Use `find_analysis_protocols` instead.",
+    )
     def get_analysis_protocols(
         self,
         analysis_protocol_name: str = None,
@@ -806,6 +1192,104 @@ class SeerSDK:
 
             return res if not as_df else dict_to_df(res)
 
+    def find_analysis_protocols(
+        self,
+        analysis_protocol_name: str = None,
+        analysis_protocol_id: str = None,
+        as_df: bool = False,
+    ):
+        """
+        Fetches a list of analysis protocols for the authenticated user. If no `analysis_protocol_id` is provided, returns all analysis protocols for the authenticated user. If `analysis_protocol_name` (and no `analysis_protocol_id`) is provided, returns the analysis protocol with the given name, provided it exists.
+
+        Parameters
+        ----------
+        analysis_protocol_id : str, optional
+            ID of the analysis protocol to be fetched, defaulted to None.
+
+        analysis_protocol_name : str, optional
+            Name of the analysis protocol to be fetched, defaulted to None.
+
+        as_df : bool, optional
+            whether the result should be converted to a DataFrame, defaulted to False.
+        Returns
+        -------
+        protocols: list[dict]
+            List of analysis protocol objects for the authenticated user.
+
+        Examples
+        -------
+        >>> from seer_pas_sdk import SeerSDK
+        >>> seer_sdk = SeerSDK()
+        >>> seer_sdk.get_analysis_protocols()
+        >>> [
+                { "id": ..., "analysis_protocol_name": ... },
+                { "id": ..., "analysis_protocol_name": ... },
+                ...
+            ]
+
+        >>> seer_sdk.get_analysis_protocols(name="YOUR_ANALYSIS_PROTOCOL_NAME_HERE")
+        >>> [{ "id": ..., "analysis_protocol_name": ... }]
+
+        >>> seer_sdk.get_analysis_protocols(id="YOUR_ANALYSIS_PROTOCOL_ID_HERE")
+        >>> [{ "id": ..., "analysis_protocol_name": ... }]
+
+        >>> seer_sdk.get_analysis_protocols(id="YOUR_ANALYSIS_PROTOCOL_ID_HERE", name="YOUR_ANALYSIS_PROTOCOL_NAME_HERE")
+
+        >>> [{ "id": ..., "analysis_protocol_name": ... }] # in this case the id would supersede the inputted name.
+        """
+
+        URL = f"{self._auth.url}api/v1/analysisProtocols"
+        res = []
+        params = {"all": "true"}
+
+        if analysis_protocol_name:
+            params.update(
+                {
+                    "searchFields": "analysis_protocol_name,offering_name",
+                    "searchItem": analysis_protocol_name,
+                }
+            )
+
+        with self._get_auth_session("findanalysisprotocols") as s:
+
+            protocols = s.get(URL, params=params)
+            if protocols.status_code != 200:
+                raise ValueError(
+                    "Invalid request. Please check your parameters."
+                )
+            if analysis_protocol_id:
+                res = [protocols.json()]
+            else:
+                res = protocols.json()["data"]
+
+            for entry in range(len(res)):
+                if "tenant_id" in res[entry]:
+                    del res[entry]["tenant_id"]
+
+                if "can_edit" in res[entry]:
+                    del res[entry]["can_edit"]
+
+                if "can_delete" in res[entry]:
+                    del res[entry]["can_delete"]
+
+                if "scope" in res[entry]:
+                    del res[entry]["scope"]
+
+                if "parameter_file_path" in res[entry]:
+                    # Simple lambda function to find the third occurrence of '/' in the raw file path
+                    location = lambda s: len(s) - len(s.split("/", 3)[-1])
+                    # Slicing the string from the location
+                    res[entry]["parameter_file_path"] = res[entry][
+                        "parameter_file_path"
+                    ][location(res[entry]["parameter_file_path"]) :]
+
+            return res if not as_df else dict_to_df(res)
+
+    @deprecation.deprecated(
+        deprecated_in="1.1.0",
+        removed_in="2.0.0",
+        text="This method is deprecated and will be removed in a future release. Use `find_analyses` instead.",
+    )
     def get_analyses(
         self,
         analysis_id: str = None,
@@ -972,7 +1456,173 @@ class SeerSDK:
                 ]
             return res if not as_df else dict_to_df(res)
 
-    @deprecation.deprecated(deprecated_in="0.3.0", removed_in="1.0.0")
+    def find_analyses(
+        self,
+        analysis_id: str = None,
+        folder_id: str = None,
+        show_folders: bool = True,
+        analysis_only: bool = True,
+        project_id: str = None,
+        plate_name: str = None,
+        as_df=False,
+        **kwargs,
+    ):
+        """
+        Returns a list of analyses objects for the authenticated user. If no id is provided, returns all analyses for the authenticated user.
+        Search parameters may be passed in as keyword arguments to filter the results. Acceptable values are 'analysis_name', 'folder_name', 'description', 'notes', or 'number_msdatafile'.
+        Only search on a single field is supported.
+
+        Parameters
+        ----------
+        analysis_id : str, optional
+            ID of the analysis to be fetched, defaulted to None.
+
+        folder_id : str, optional
+            ID of the folder to be fetched, defaulted to None.
+
+        show_folders : bool, optional
+            Mark True if folder contents are to be returned in the response, i.e. recursive search, defaulted to True.
+            Will be disabled if an analysis id is provided.
+
+        analysis_only : bool, optional
+            Mark True if only analyses objects are to be returned in the response, defaulted to True.
+            If marked false, folder objects will also be included in the response.
+
+        project_id : str, optional
+            ID of the project to be fetched, defaulted to None.
+
+        plate_name : str, optional
+            Name of the plate to be fetched, defaulted to None.
+
+        as_df : bool, optional
+            whether the result should be converted to a DataFrame, defaulted to False.
+
+        **kwargs : dict, optional
+            Search keyword parameters to be passed in. Acceptable values are 'analysis_name', 'folder_name', 'analysis_protocol_name', 'description', 'notes', or 'number_msdatafile'.
+
+        Returns
+        -------
+        analyses: list[dict]
+            Contains a list of analyses objects for the authenticated user.
+
+        Examples
+        -------
+        >>> from seer_pas_sdk import SeerSDK
+        >>> seer_sdk = SeerSDK()
+        >>> seer_sdk.get_analyses()
+        >>> [
+                {id: "YOUR_ANALYSIS_ID_HERE", ...},
+                {id: "YOUR_ANALYSIS_ID_HERE", ...},
+                {id: "YOUR_ANALYSIS_ID_HERE", ...}
+            ]
+
+        >>> seer_sdk.get_analyses("YOUR_ANALYSIS_ID_HERE")
+        >>> [{ id: "YOUR_ANALYSIS_ID_HERE", ...}]
+
+        >>> seer_sdk.get_analyses(folder_name="YOUR_FOLDER_NAME_HERE")
+        >>> [{ id: "YOUR_ANALYSIS_ID_HERE", ...}]
+
+        >>> seer_sdk.get_analyses(analysis_name="YOUR_ANALYSIS")
+        >>> [{ id: "YOUR_ANALYSIS_ID_HERE", ...}]
+
+        >>> seer_sdk.get_analyses(description="YOUR_DESCRIPTION")
+        >>> [{ id: "YOUR_ANALYSIS_ID_HERE", ...}]
+        """
+
+        URL = f"{self._auth.url}api/v1/analyses"
+        res = []
+
+        search_field = None
+        search_item = None
+        if kwargs:
+            if len(kwargs.keys()) > 1:
+                raise ValueError("Please include only one search parameter.")
+            search_field = list(kwargs.keys())[0]
+            search_item = kwargs[search_field]
+
+            if not search_item:
+                raise ValueError(
+                    f"Please provide a non null value for {search_field}"
+                )
+
+        if search_field and search_field not in [
+            "analysis_name",
+            "folder_name",
+            "analysis_protocol_name",
+            "description",
+            "notes",
+            "number_msdatafile",
+        ]:
+            raise ValueError(
+                "Invalid search field. Please choose between 'analysis_name', 'folder_name', 'analysis_protocol_name', 'description', 'notes', or 'number_msdatafile'."
+            )
+
+        with self._get_auth_session("findanalyses") as s:
+
+            params = {"all": "true"}
+            if folder_id:
+                params["folder"] = folder_id
+
+            if search_field:
+                params["searchFields"] = search_field
+                params["searchItem"] = search_item
+                del params["all"]
+
+                if search_field == "folder_name":
+                    params["searchFields"] = "analysis_name"
+
+            if project_id:
+                params["projectId"] = project_id
+
+            if plate_name:
+                params["plateName"] = plate_name
+
+            analyses = s.get(
+                f"{URL}/{analysis_id}" if analysis_id else URL, params=params
+            )
+
+            if analyses.status_code != 200:
+                raise ValueError(
+                    "Invalid request. Please check your parameters."
+                )
+            if not analysis_id:
+                res = analyses.json()["data"]
+
+            else:
+                res = [analyses.json()["analysis"]]
+
+            folders = []
+            for entry in range(len(res)):
+                if "tenant_id" in res[entry]:
+                    del res[entry]["tenant_id"]
+
+                if "parameter_file_path" in res[entry]:
+                    # Simple lambda function to find the third occurrence of '/' in the raw file path
+                    location = lambda s: len(s) - len(s.split("/", 3)[-1])
+
+                    # Slicing the string from the location
+                    res[entry]["parameter_file_path"] = res[entry][
+                        "parameter_file_path"
+                    ][location(res[entry]["parameter_file_path"]) :]
+
+                if (
+                    show_folders
+                    and not analysis_id
+                    and res[entry]["is_folder"]
+                ):
+                    folders.append(res[entry]["id"])
+
+            # recursive solution to get analyses in folders
+            for folder in folders:
+                res += self.get_analyses(folder_id=folder)
+
+            if analysis_only:
+                res = [
+                    analysis for analysis in res if not analysis["is_folder"]
+                ]
+            return res if not as_df else dict_to_df(res)
+
+    @deprecation.deprecated(deprecated_in="0.3.0", removed_in="2.0.0")
     def get_analysis_result_protein_data(
         self, analysis_id: str, link: bool = False, pg: str = None
     ):
@@ -1045,7 +1695,7 @@ class SeerSDK:
                         "protein_panel": protein_panel,
                     }
 
-    @deprecation.deprecated(deprecated_in="0.3.0", removed_in="1.0.0")
+    @deprecation.deprecated(deprecated_in="0.3.0", removed_in="2.0.0")
     def get_analysis_result_peptide_data(
         self, analysis_id: str, link: bool = False, peptide: str = None
     ):
@@ -1461,7 +2111,7 @@ class SeerSDK:
         response["filename"] = filename
         return response
 
-    @deprecation.deprecated(deprecated_in="0.3.0", removed_in="1.0.0")
+    @deprecation.deprecated(deprecated_in="0.3.0", removed_in="2.0.0")
     def get_analysis_result_files(
         self,
         analysis_id: str,
@@ -1604,7 +2254,7 @@ class SeerSDK:
 
         return links
 
-    @deprecation.deprecated(deprecated_in="0.3.0", removed_in="1.0.0")
+    @deprecation.deprecated(deprecated_in="0.3.0", removed_in="2.0.0")
     def get_analysis_result(
         self,
         analysis_id: str,


### PR DESCRIPTION
1. Introduce unitary query functions as "get_{entity}" for projects, plates, analysis, analysis protocol
2. Introduce multiple query functions as "find_{entities}" for projects, plates, samples, analyses, analysis protocols, msruns
3. Deprecate existing query functions as these had dual responsibility for the above.
     a. Effective for projects, plates, samples, analyses, analysis_protocols, msruns
4. Update documentation to reflect these changes. 