### PR TITLE
RS-6286

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -790,3 +790,62 @@ log(sdk.group_analysis_results(group_analysis_id, box_plot_info))
 ```
 
 <hr>
+
+###Download Analysis Protocol FASTA
+
+Downloads the FASTA file(s) associated with an analysis protocol. You can specify an analysis_id (the function will resolve the protocol automatically) or provide an analysis_protocol_id directly. Optionally, return signed download links instead of downloading.
+
+######<u>Params</u>
+
+* `analysis_id`: (`str`, optional) ID of the analysis whose protocol FASTA file(s) you want.
+
+* `analysis_protocol_id`: (`str`, optional) ID of the analysis protocol whose FASTA file(s) you want.
+
+* `link`: (`bool`, optional) If True, returns signed download links without downloading files. Defaults to False.
+
+* `download_path`: (`str`, optional) Directory to save files to. Defaults to the current working directory.
+
+Note: Provide either analysis_id or analysis_protocol_id (but not both).
+
+<br>
+######<u>Returns</u>
+
+* `list[dict] | None` — If link=True, returns a list of dictionaries with filename and url. Otherwise downloads files to download_path and returns None.
+
+<br>
+
+###### <u>Examples</u>
+
+Download by analysis ID (files saved to current directory):
+```{python}
+#| eval: false
+sdk.download_analysis_protocol_fasta(
+    analysis_id="c80a0260-856e-11ee-b1b7-ff20dde1461b"
+)
+```
+
+Download by analysis protocol ID to a specific folder:
+```{python}
+#| eval: false
+sdk.download_analysis_protocol_fasta(
+    analysis_protocol_id="dc61a360-6b77-11ed-8ac3-37d35135f08e",
+    download_path="/path/to/fasta"
+)
+```
+
+Get links only (no download):
+```{python}
+#| eval: false
+links = sdk.download_analysis_protocol_fasta(
+    analysis_protocol_id="dc61a360-6b77-11ed-8ac3-37d35135f08e",
+    link=True
+)
+log(links)
+```
+```
+[
+  {"filename": "uniprot_human_2023_08.fasta", "url": "https://...signed..."},
+  {"filename": "contaminants.fasta", "url": "https://...signed..."}
+]
+```
+<br>

--- a/seer_pas_sdk/core/sdk.py
+++ b/seer_pas_sdk/core/sdk.py
@@ -2850,6 +2850,97 @@ class SeerSDK:
         resp.drop_duplicates(subset=["id"], inplace=True)
         return resp if as_df else resp.to_dict(orient="records")
 
+    @deprecation.deprecated(
+        deprecated_in="1.1.0",
+        removed_in="2.0.0",
+        details="get_analysis_protocol_fasta is deprecated. Use download_analysis_protocol_fasta instead.",
+    )
+    def get_analysis_protocol_fasta(self, analysis_id, download_path=None):
+        if not analysis_id:
+            raise ValueError("Analysis ID cannot be empty.")
+
+        if not download_path:
+            download_path = os.getcwd()
+
+        try:
+            analysis_protocol_id = self.get_analyses(analysis_id)[0][
+                "analysis_protocol_id"
+            ]
+        except (IndexError, KeyError):
+            raise ValueError(f"Could not parse server response.")
+
+        try:
+            analysis_protocol_engine = self.get_analysis_protocols(
+                analysis_protocol_id=analysis_protocol_id
+            )[0]["analysis_engine"]
+        except (IndexError, KeyError):
+            raise ValueError(f"Could not parse server response.")
+
+        analysis_protocol_engine = analysis_protocol_engine.lower()
+        if analysis_protocol_engine == "diann":
+            URL = f"{self._auth.url}api/v1/analysisProtocols/editableParameters/diann/{analysis_protocol_id}"
+        elif analysis_protocol_engine == "encyclopedia":
+            URL = f"{self._auth.url}api/v1/analysisProtocols/editableParameters/dia/{analysis_protocol_id}"
+        elif analysis_protocol_engine == "msfragger":
+            URL = f"{self._auth.url}api/v1/analysisProtocols/editableParameters/msfragger/{analysis_protocol_id}"
+        elif analysis_protocol_engine == "proteogenomics":
+            URL = f"{self._auth.url}api/v1/analysisProtocols/editableParameters/proteogenomics/{analysis_protocol_id}"
+        else:
+            # Change needed on the backend to get s3 file path for MaxQuant
+            # URL = f"{self._auth.url}api/v1/analysisProtocols/editableParameters/{analysis_protocol_id}"
+            raise ValueError(
+                f"Analysis protocol engine {analysis_protocol_engine} not supported for fasta download."
+            )
+
+        with self._get_auth_session() as s:
+            response = s.get(URL)
+            if response.status_code != 200:
+                raise ServerError("Request failed.")
+            response = response.json()
+            if type(response) == dict:
+                response = response["editableParameters"]
+            fasta_filenames = [
+                x["Value"]
+                for x in response
+                if x["Key"] in ["fasta", "fastaFilePath", "referencegenome"]
+            ]
+            if not fasta_filenames:
+                raise ServerError("No fasta file name returned from server.")
+
+        URL = f"{self._auth.url}api/v1/analysisProtocolFiles/getUrl"
+        for file in fasta_filenames:
+            with self._get_auth_session() as s:
+                response = s.post(URL, json={"filepath": file})
+                if response.status_code != 200:
+                    raise ServerError("Request failed.")
+                url = response.json()["url"]
+                filename = os.path.basename(file)
+                print(f"Downloading {filename}")
+                for _ in range(2):
+                    try:
+                        with tqdm(
+                            unit="B",
+                            unit_scale=True,
+                            unit_divisor=1024,
+                            miniters=1,
+                            desc=f"Progress",
+                        ) as t:
+                            ssl._create_default_https_context = (
+                                ssl._create_unverified_context
+                            )
+                            urllib.request.urlretrieve(
+                                url,
+                                f"{download_path}/{filename}",
+                                reporthook=download_hook(t),
+                                data=None,
+                            )
+                            break
+                    except:
+                        if not os.path.isdir(f"{download_path}"):
+                            os.makedirs(f"{download_path}")
+
+                print(f"Downloaded file to {download_path}/{file}")
+
     def download_analysis_protocol_fasta(
         self,
         analysis_id=None,


### PR DESCRIPTION
1. Rename get_analysis_protocol_fasta to download_analysis_protocol_fasta
2. introduce analysis_protocol_id as a query parameter
3. enable `link` flag parameter to return a signed url instead of an automatic download 