### PR TITLE
enable download of analysis result files located in a PAS folder

### DIFF
--- a/seer_pas_sdk/core/sdk.py
+++ b/seer_pas_sdk/core/sdk.py
@@ -2353,8 +2353,7 @@ class SeerSDK:
                     break
             except:
                 dirname = f"{download_path}/{os.path.dirname(filename)}"
-                basename = os.path.basename(filename)
-                if not os.path.isdir(f"{dirname}/{basename}"):
+                if not os.path.isdir(f"{dirname}"):
                     os.makedirs(f"{dirname}/")
         return f"{download_path}/{filename}"
 

--- a/seer_pas_sdk/core/sdk.py
+++ b/seer_pas_sdk/core/sdk.py
@@ -1857,15 +1857,18 @@ class SeerSDK:
                 "Invalid search field. Please choose between 'analysis_name', 'folder_name', 'analysis_protocol_name', 'description', 'notes', or 'number_msdatafile'."
             )
 
+        if analysis_id:
+            try:
+                return [self.get_analysis(analysis_id=analysis_id)]
+            except:
+                return []
+
         with self._get_auth_session("findanalyses") as s:
 
             params = {"all": "true"}
             if folder_id:
                 params["folder"] = folder_id
 
-            if analysis_id:
-                params["searchFields"] = "id"
-                params["searchItem"] = analysis_id
             if search_field:
                 params["searchFields"] = search_field
                 params["searchItem"] = search_item

--- a/seer_pas_sdk/core/sdk.py
+++ b/seer_pas_sdk/core/sdk.py
@@ -2323,6 +2323,9 @@ class SeerSDK:
         if not download_path:
             download_path = os.getcwd()
 
+        if download_path.endswith("/"):
+            download_path = download_path.rstrip("/")
+
         if not analysis_id:
             raise ValueError("Analysis ID cannot be empty.")
 

--- a/seer_pas_sdk/core/sdk.py
+++ b/seer_pas_sdk/core/sdk.py
@@ -2357,7 +2357,7 @@ class SeerSDK:
             except:
                 dirname = f"{download_path}/{os.path.dirname(filename)}"
                 if not os.path.isdir(f"{dirname}"):
-                    os.makedirs(f"{dirname}/")
+                    os.makedirs(f"{dirname}")
         return f"{download_path}/{filename}"
 
     def get_search_result_file_url(self, analysis_id: str, filename: str):


### PR DESCRIPTION
1. the SDK will now take folder name into account when querying for a search result file url - also applies to search result file download. 
2. Clean up local file system folder creation when downloading a search result file 