### PR TITLE
Act on deprecation of get_analysis_protocols to find_analysis_protocols

### DIFF
--- a/seer_pas_sdk/core/sdk.py
+++ b/seer_pas_sdk/core/sdk.py
@@ -3972,7 +3972,7 @@ class SeerSDK:
                 raise ValueError(f"Could not parse server response.")
 
         try:
-            analysis_protocol_engine = self.get_analysis_protocols(
+            analysis_protocol_engine = self.find_analysis_protocols(
                 analysis_protocol_id=analysis_protocol_id
             )[0]["analysis_engine"]
         except (IndexError, KeyError):


### PR DESCRIPTION
get_analysis_protocols() used in an internal function. Replaced with the newer find_analysis_protocols(). All automation tests pass.