### PR TITLE
RS-6649: add fasta filenames to analysis query response

### DIFF
--- a/seer_pas_sdk/core/sdk.py
+++ b/seer_pas_sdk/core/sdk.py
@@ -4039,16 +4039,29 @@ class SeerSDK:
             return fasta_filenames
 
     def get_analysis_protocol_fasta_link(
-        self, analysis_protocol_id=None, analysis_id=None
+        self, analysis_protocol_id=None, analysis_id=None, analysis_name=None
     ):
         """Get the download link(s) for the fasta file(s) associated with a given analysis protocol.
         Args:
             analysis_protocol_id (str,optional): ID of the analysis protocol. Defaults to None.
             analysis_id (str, optional): ID of the analysis. Defaults to None.
+            analysis_name (str, optional): Name of the analysis. Defaults to None.
 
         Returns:
             list[dict]: A list of dictionaries containing the 'filename' and the 'url' to download the fasta file.
         """
+        if analysis_name and (not analysis_id):
+            analyses = self.find_analyses(analysis_name=analysis_name)
+            if len(analyses) > 1:
+                raise ValueError(
+                    f"Multiple analyses found with name {analysis_name}. Please provide an analysis ID instead."
+                )
+            elif len(analyses) == 0:
+                raise ValueError(
+                    f"No analyses found with name {analysis_name}."
+                )
+            else:
+                analysis_id = analyses[0]["id"]
 
         if not (bool(analysis_protocol_id) ^ bool(analysis_id)):
             raise ValueError(
@@ -4057,10 +4070,10 @@ class SeerSDK:
 
         if not analysis_protocol_id:
             try:
-                analysis_protocol_id = self.get_analyses(analysis_id)[0][
-                    "analysis_protocol_id"
-                ]
-            except (IndexError, KeyError):
+                analysis_protocol_id = self.get_analysis(
+                    analysis_id=analysis_id
+                )["analysis_protocol_id"]
+            except KeyError:
                 raise ValueError(f"Could not parse server response.")
 
         fasta_filenames = self._get_analysis_protocol_fasta_filenames(

--- a/seer_pas_sdk/core/sdk.py
+++ b/seer_pas_sdk/core/sdk.py
@@ -1795,11 +1795,22 @@ class SeerSDK:
                 if "user_group" in res:
                     res["space"] = spaces.get(res["user_group"], "General")
                     del res["user_group"]
-                res["fasta"] = (
-                    ','.join(self._get_analysis_protocol_fasta_filenames(
-                        analysis_protocol_id=res.get("analysis_protocol_id")
-                    ))
-                )
+                if not res.get("is_folder") and res.get(
+                    "analysis_protocol_id"
+                ):
+                    try:
+                        res["fasta"] = ",".join(
+                            self._get_analysis_protocol_fasta_filenames(
+                                analysis_protocol_id=res.get(
+                                    "analysis_protocol_id"
+                                )
+                            )
+                        )
+                    except Exception as e:
+                        print("Warning: Could not fetch fasta files.")
+                        res["fasta"] = None
+                else:
+                    res["fasta"] = None
                 return res
         else:
             res = self.find_analyses(analysis_name=analysis_name)
@@ -1976,11 +1987,22 @@ class SeerSDK:
                     )
                     del res[entry]["user_group"]
 
-                res[entry]["fasta"] = ",".join(
-                    self._get_analysis_protocol_fasta_filenames(
-                        res[entry]["analysis_protocol_id"]
-                    )
-                )
+                if (not res[entry].get("is_folder")) and res[entry].get(
+                    "analysis_protocol_id"
+                ):
+                    try:
+                        res[entry]["fasta"] = ",".join(
+                            self._get_analysis_protocol_fasta_filenames(
+                                res[entry]["analysis_protocol_id"]
+                            )
+                        )
+                    except:
+                        print(
+                            f"Warning: Could not fetch fasta files for analysis {res[entry].get('analysis_name')}."
+                        )
+                        res[entry]["fasta"] = None
+                else:
+                    res[entry]["fasta"] = None
 
             # recursive solution to get analyses in folders
             for folder in folders:
@@ -3978,7 +4000,7 @@ class SeerSDK:
             analysis_protocol_engine = self.get_analysis_protocol(
                 analysis_protocol_id=analysis_protocol_id
             )["analysis_engine"]
-        except (KeyError):
+        except KeyError:
             raise ServerError(f"Could not find analysis protocol parameters.")
 
         analysis_protocol_engine = analysis_protocol_engine.lower()

--- a/seer_pas_sdk/objects/headers.py
+++ b/seer_pas_sdk/objects/headers.py
@@ -82,6 +82,7 @@ ANALYSIS_COLUMNS = [
     "number_sample",
     "total_file_size_mb",
     "msdatafile_extensions",
+    "fasta",
 ]
 
 ANALYSIS_PROTOCOL_COLUMNS = [
@@ -107,6 +108,7 @@ ANALYSIS_PROTOCOL_COLUMNS = [
     "last_modified_timestamp",
     "go_version",
     "space",
+    "fasta",
 ]
 
 MSRUN_COLUMNS = [


### PR DESCRIPTION
1. move fasta filename query out of fasta link query to be a helper function 
2. get / find functions for analysis returns fasta file names as stringfied list, keyed as 'fasta'
3. If an analysis record is determined to be a folder, fasta value will be None.
4. If an error is returned from the backend API when querying for fasta filename, the analysis record(s) will still be returned, with fasta value as None in affected rows. 