### PR TITLE
RS-6733 Fix token refresh

### DIFF
--- a/seer_pas_sdk/auth/auth.py
+++ b/seer_pas_sdk/auth/auth.py
@@ -214,6 +214,7 @@ class Auth:
         if response.status_code == 200:
             return response.json()
         else:
+            print(response.text)
             raise ServerError("Could not refresh token")
 
     def get_token(self):
@@ -234,8 +235,6 @@ class Auth:
             raise ValueError(
                 "Check if the credentials are correct or if the backend is running or not."
             )
-
-        self.refresh_token = res.get("refresh_token", None)
         self.token_expiry = int(datetime.now().timestamp()) + res.get(
             "expiresIn", 0
         )

--- a/seer_pas_sdk/auth/auth.py
+++ b/seer_pas_sdk/auth/auth.py
@@ -191,14 +191,14 @@ class Auth:
         )
         return True
 
-    def _get_refresh_token(self):
-        """Refreshes the refresh token using the current refresh token.
+    def _refresh_token(self):
+        """Refreshes the token using the refresh token.
 
         Raises:
-            ServerError: If the refresh token could not be refreshed.
+            ServerError: If the token could not be refreshed.
 
         Returns:
-            dict: The response from the server containing the new refresh token.
+            dict: The response from the server containing the new token.
         """
         s = requests.Session()
         s.headers.update(
@@ -214,7 +214,6 @@ class Auth:
         if response.status_code == 200:
             return response.json()
         else:
-            print(response.text)
             raise ServerError("Could not refresh token")
 
     def get_token(self):

--- a/seer_pas_sdk/core/sdk.py
+++ b/seer_pas_sdk/core/sdk.py
@@ -2981,7 +2981,6 @@ class SeerSDK:
 
         for path in paths:
             with self._get_auth_session("getmsdataindexurl") as s:
-
                 download_url = s.post(
                     URL,
                     json={


### PR DESCRIPTION
Remove statement erroneously replacing the SDK refresh token with an expected refresh token value from the server. The server response does not have a refresh token value, therefore this was setting the refresh token to null when refresh was called the second time in a session. 